### PR TITLE
Fixes saving rgba values as hex. Adds nuget.config

### DIFF
--- a/Jellyfin.Plugin.SkinManager/Configuration/configurationpage.html
+++ b/Jellyfin.Plugin.SkinManager/Configuration/configurationpage.html
@@ -179,7 +179,7 @@
                 var description = option.description;
                 var mode = option.mode == undefined ? "hex" : option.mode;
                 // change mode based on color value
-                mode = getColorType(defaultValue);
+                mode = getColorMode(defaultValue);
 
                 html +=
                     '<div class="inputContainer"><label></span>' +
@@ -776,7 +776,29 @@
                         Array.from(document.getElementsByClassName("color")).forEach(
                             (element) => {
                                 if (option.css == element.getAttribute("data-css")) {
-                                    result = element.value;
+                                    var values = $("#" + element.name).spectrum("get")
+
+                                    // Get color mode from values
+                                    var mode = getColorMode(values);
+                                    // Update "data-mode" if changed. (Ex, hex color is now rgba)
+                                    if (mode != element.getAttribute("data-mode")) {
+                                        element.setAttribute("data-mode", mode);
+                                    }
+
+                                    var color = "";
+
+                                    switch (mode) {
+                                        case "hex":
+                                            color = "#" + values.toHex();
+                                            break;
+                                        case "only_numbers":
+                                            color = values._r + "," + values._g + "," + values._b;
+                                            break;
+                                        default:
+                                            color = "rgba(" + Math.round(values._r) + "," + Math.round(values._g) + "," + Math.round(values._b) + "," + values._a + ")";
+                                            break;
+                                    }
+                                    result = color;
                                 }
                             }
                         );
@@ -820,8 +842,8 @@
                 return result;
             }
 
-            function getColorType(color) {
-                var trimLeft = /^[\s]+/,
+            function getColorMode(color) {
+                var trimLeft = /^[\s,#]+/,
                     trimRight = /\s+$/;
                 color = String(color).replace(trimLeft, '').replace(trimRight, '').toLowerCase();
                 var named = false;
@@ -849,13 +871,11 @@
                 if ((match = matchers.hsva.exec(color))) {
                     return "hsva";
                 }
-                if ((match = matchers.hex8.exec(color))) {
-                    return "hex";
-                }
-                if ((match = matchers.hex6.exec(color))) {
-                    return "hex";
-                }
-                if ((match = matchers.hex3.exec(color))) {
+                if (
+                    (match = matchers.hex8.exec(color)) ||
+                    (match = matchers.hex6.exec(color)) ||
+                    (match = matchers.hex3.exec(color))
+                ) {
                     return "hex";
                 }
 
@@ -886,9 +906,9 @@
                     hsla: new RegExp("hsla" + PERMISSIVE_MATCH4),
                     hsv: new RegExp("hsv" + PERMISSIVE_MATCH3),
                     hsva: new RegExp("hsva" + PERMISSIVE_MATCH4),
-                    hex3: /^#?([0-9a-fA-F]{1})([0-9a-fA-F]{1})([0-9a-fA-F]{1})$/,
-                    hex6: /^#?([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})$/,
-                    hex8: /^#?([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})$/
+                    hex3: /^([0-9a-fA-F]{1})([0-9a-fA-F]{1})([0-9a-fA-F]{1})$/,
+                    hex6: /^([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})$/,
+                    hex8: /^([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})$/
                 };
             })();
 

--- a/Jellyfin.Plugin.SkinManager/Configuration/configurationpage.html
+++ b/Jellyfin.Plugin.SkinManager/Configuration/configurationpage.html
@@ -177,13 +177,16 @@
                 colorPickers[id] = defaultValue
                 var css = option.css;
                 var description = option.description;
-                var mode = option.mode;
+                //var mode = "rgb";// option.mode;
+                var mode = option.mode == undefined ? "hex" : option.mode;
+                mode = getColorType(defaultValue);
+                //console.log("defaultMode: " + mode);
                 html +=
                     '<div class="inputContainer"><label></span>' +
                     getToolTip(option) +
                     '</label><input class = color type=text  value="' +
                     defaultValue +
-                    '"data-css = "' +
+                    '" data-css="' +
                     css +
                     '" data-mode="' +
                     mode +
@@ -198,6 +201,7 @@
                     '<div class="fieldDescription">' +
                     description +
                     "</div></div>";
+                //console.log("HTML:" + html);
                 return html;
             }
 
@@ -443,10 +447,15 @@
                             color = values._r + "," + values._g + "," + values._b ;
                             break;
                         default:
-                            color = "rgba(" + values._r + "," + values._g + "," + values._b + "," + values._a + ")";
+                            color = "rgba(" + Math.round(values._r) + "," + Math.round(values._g) + "," + Math.round(values._b) + "," + values._a + ")";
                             break;
                     }
+                    //console.log("createCss()::Print name: " + element.name);
+                    //console.log("createCss()::Print values: " + values);
+                    //console.log("createCss()::Print mode: " + mode);
+                    //console.log("createCss()::Print color: " + color);
                     css += element.getAttribute("data-css").replaceAll("$", color) + "\n";
+                    //css += element.getAttribute("data-css").replaceAll("$", values) + "\n";
                 }
 
                 //procces number selector
@@ -720,7 +729,7 @@
             function saveConfig() {
                 var pluginId = "e9ca8b8e-ca6d-40e7-85dc-58e536df8eb3";
                 config.selectedSkin = $("#cssOptions").val();
-
+                
                 var options = [];
                 var count = 0;
                 data[
@@ -772,6 +781,37 @@
                             (element) => {
                                 if (option.css == element.getAttribute("data-css")) {
                                     result = element.value;
+
+
+                                    // Output hex, rgba, numbers correctly to config
+                                    //var values = $("#" + element.name).spectrum("get")
+                                    //var mode = element.getAttribute("data-mode");
+                                    //var color = "";
+
+                                    //switch (mode) {
+                                    //    case "hex":
+                                    //        color = "#" + values.toHex();
+                                    //        break;
+                                    //    case "only_numbers":
+                                    //        color = values._r + "," + values._g + "," + values._b;
+                                    //        break;
+                                    //    default:
+                                    //        color = "rgba(" + Math.round(values._r) + "," + Math.round(values._g) + "," + Math.round(values._b) + "," + values._a + ")";
+                                    //        break;
+                                    //}
+                                    //console.log("getValue()::Print name: " + element.name);
+                                    //console.log("getValue()::Print value: " + element.value);
+                                    //console.log("getValue()::Print values: " + values);
+                                    //console.log("getValue()::Print mode: " + mode);
+                                    //console.log("getValue()::Print color: " + color);
+
+                                    //var colorB = tinyColor(values);
+                                    //console.log("getValue()::Print tinyColorB: " + colorB + " colorB.colorFormat(): " + colorB.getFormat());
+
+                                    //console.log("getValue()::Print color: " + color + " color.colorFormat(): " + color.getFormat());
+                                    //result = color;
+                                    //result = String(values);
+                                    //result = String(element.value);
                                 }
                             }
                         );
@@ -814,6 +854,85 @@
                 }
                 return result;
             }
+
+            function getColorType(color) {
+                var trimLeft = /^[\s]+/,
+                    trimRight = /\s+$/;
+                color = String(color).replace(trimLeft, '').replace(trimRight, '').toLowerCase();
+                var named = false;
+                //if (names[color]) {
+                //    color = names[color];
+                //    named = true;
+                //}
+                //else if (color == 'transparent') {
+                //    return { r: 0, g: 0, b: 0, a: 0, format: "name" };
+                //}
+
+                // Try to match string input using regular expressions.
+                // Keep most of the number bounding out of this function - don't worry about [0,1] or [0,100] or [0,360]
+                // Just return an object and let the conversion functions handle that.
+                // This way the result will be the same whether the tinycolor is initialized with string or object.
+                var match;
+                if ((match = matchers.rgb.exec(color))) {
+                    return "rgb";
+                }
+                if ((match = matchers.rgba.exec(color))) {
+                    return "rgba";
+                }
+                if ((match = matchers.hsl.exec(color))) {
+                    return "hsl";
+                }
+                if ((match = matchers.hsla.exec(color))) {
+                    return "hsla";
+                }
+                if ((match = matchers.hsv.exec(color))) {
+                    return "hsv";
+                }
+                if ((match = matchers.hsva.exec(color))) {
+                    return "hsva";
+                }
+                if ((match = matchers.hex8.exec(color))) {
+                    return "hex";
+                }
+                if ((match = matchers.hex6.exec(color))) {
+                    return "hex";
+                }
+                if ((match = matchers.hex3.exec(color))) {
+                    return "hex";
+                }
+
+                return false;
+            }
+
+            var matchers = (function () {
+
+                // <http://www.w3.org/TR/css3-values/#integers>
+                var CSS_INTEGER = "[-\\+]?\\d+%?";
+
+                // <http://www.w3.org/TR/css3-values/#number-value>
+                var CSS_NUMBER = "[-\\+]?\\d*\\.\\d+%?";
+
+                // Allow positive/negative integer/number.  Don't capture the either/or, just the entire outcome.
+                var CSS_UNIT = "(?:" + CSS_NUMBER + ")|(?:" + CSS_INTEGER + ")";
+
+                // Actual matching.
+                // Parentheses and commas are optional, but not required.
+                // Whitespace can take the place of commas or opening paren
+                var PERMISSIVE_MATCH3 = "[\\s|\\(]+(" + CSS_UNIT + ")[,|\\s]+(" + CSS_UNIT + ")[,|\\s]+(" + CSS_UNIT + ")\\s*\\)?";
+                var PERMISSIVE_MATCH4 = "[\\s|\\(]+(" + CSS_UNIT + ")[,|\\s]+(" + CSS_UNIT + ")[,|\\s]+(" + CSS_UNIT + ")[,|\\s]+(" + CSS_UNIT + ")\\s*\\)?";
+
+                return {
+                    rgb: new RegExp("rgb" + PERMISSIVE_MATCH3),
+                    rgba: new RegExp("rgba" + PERMISSIVE_MATCH4),
+                    hsl: new RegExp("hsl" + PERMISSIVE_MATCH3),
+                    hsla: new RegExp("hsla" + PERMISSIVE_MATCH4),
+                    hsv: new RegExp("hsv" + PERMISSIVE_MATCH3),
+                    hsva: new RegExp("hsva" + PERMISSIVE_MATCH4),
+                    hex3: /^#?([0-9a-fA-F]{1})([0-9a-fA-F]{1})([0-9a-fA-F]{1})$/,
+                    hex6: /^#?([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})$/,
+                    hex8: /^#?([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})$/
+                };
+            })();
 
             function checkEasterEggs() {
                 var d = new Date();

--- a/Jellyfin.Plugin.SkinManager/Configuration/configurationpage.html
+++ b/Jellyfin.Plugin.SkinManager/Configuration/configurationpage.html
@@ -177,10 +177,10 @@
                 colorPickers[id] = defaultValue
                 var css = option.css;
                 var description = option.description;
-                //var mode = "rgb";// option.mode;
                 var mode = option.mode == undefined ? "hex" : option.mode;
+                // change mode based on color value
                 mode = getColorType(defaultValue);
-                //console.log("defaultMode: " + mode);
+
                 html +=
                     '<div class="inputContainer"><label></span>' +
                     getToolTip(option) +
@@ -201,7 +201,7 @@
                     '<div class="fieldDescription">' +
                     description +
                     "</div></div>";
-                //console.log("HTML:" + html);
+
                 return html;
             }
 
@@ -450,12 +450,8 @@
                             color = "rgba(" + Math.round(values._r) + "," + Math.round(values._g) + "," + Math.round(values._b) + "," + values._a + ")";
                             break;
                     }
-                    //console.log("createCss()::Print name: " + element.name);
-                    //console.log("createCss()::Print values: " + values);
-                    //console.log("createCss()::Print mode: " + mode);
-                    //console.log("createCss()::Print color: " + color);
+
                     css += element.getAttribute("data-css").replaceAll("$", color) + "\n";
-                    //css += element.getAttribute("data-css").replaceAll("$", values) + "\n";
                 }
 
                 //procces number selector
@@ -781,37 +777,6 @@
                             (element) => {
                                 if (option.css == element.getAttribute("data-css")) {
                                     result = element.value;
-
-
-                                    // Output hex, rgba, numbers correctly to config
-                                    //var values = $("#" + element.name).spectrum("get")
-                                    //var mode = element.getAttribute("data-mode");
-                                    //var color = "";
-
-                                    //switch (mode) {
-                                    //    case "hex":
-                                    //        color = "#" + values.toHex();
-                                    //        break;
-                                    //    case "only_numbers":
-                                    //        color = values._r + "," + values._g + "," + values._b;
-                                    //        break;
-                                    //    default:
-                                    //        color = "rgba(" + Math.round(values._r) + "," + Math.round(values._g) + "," + Math.round(values._b) + "," + values._a + ")";
-                                    //        break;
-                                    //}
-                                    //console.log("getValue()::Print name: " + element.name);
-                                    //console.log("getValue()::Print value: " + element.value);
-                                    //console.log("getValue()::Print values: " + values);
-                                    //console.log("getValue()::Print mode: " + mode);
-                                    //console.log("getValue()::Print color: " + color);
-
-                                    //var colorB = tinyColor(values);
-                                    //console.log("getValue()::Print tinyColorB: " + colorB + " colorB.colorFormat(): " + colorB.getFormat());
-
-                                    //console.log("getValue()::Print color: " + color + " color.colorFormat(): " + color.getFormat());
-                                    //result = color;
-                                    //result = String(values);
-                                    //result = String(element.value);
                                 }
                             }
                         );
@@ -860,13 +825,6 @@
                     trimRight = /\s+$/;
                 color = String(color).replace(trimLeft, '').replace(trimRight, '').toLowerCase();
                 var named = false;
-                //if (names[color]) {
-                //    color = names[color];
-                //    named = true;
-                //}
-                //else if (color == 'transparent') {
-                //    return { r: 0, g: 0, b: 0, a: 0, format: "name" };
-                //}
 
                 // Try to match string input using regular expressions.
                 // Keep most of the number bounding out of this function - don't worry about [0,1] or [0,100] or [0,360]

--- a/Jellyfin.Plugin.SkinManager/Configuration/configurationpage.html
+++ b/Jellyfin.Plugin.SkinManager/Configuration/configurationpage.html
@@ -798,6 +798,7 @@
                                             color = "rgba(" + Math.round(values._r) + "," + Math.round(values._g) + "," + Math.round(values._b) + "," + values._a + ")";
                                             break;
                                     }
+
                                     result = color;
                                 }
                             }

--- a/Jellyfin.Plugin.SkinManager/Configuration/fontpicker.js
+++ b/Jellyfin.Plugin.SkinManager/Configuration/fontpicker.js
@@ -18,7 +18,7 @@
 		'arabic': 'Arabic',
 		'bengali': 'Bengali',
 		'chinese-hongkong': 'Chinese (Hong Kong)',
-		'chinese-simplified': 'Chinese (Simplified',
+		'chinese-simplified': 'Chinese (Simplified)',
 		'chinese-traditional': 'Chinese (Traditional)',
 		'cyrillic': 'Cyrillic',
 		'cyrillic-ext': 'Cyrillic Extended',
@@ -5431,7 +5431,7 @@
 						$('.fp-pill[data-font-weight='+fw+']', $activeLi).trigger('click');
 						return;
 					}
-                    var $nextLi = undefined
+                    var $nextLi = undefined;
 					switch(e.keyCode) {
 						case 73: // i, italic
 							stop(e);
@@ -5579,7 +5579,7 @@
 								__cookie('recents', recentFonts.join(','));
 							}
 						})
-					)
+					);
 					$btns.appendTo($li);
 
 					var font = this.allFonts[fontType][fontFamily],
@@ -5595,7 +5595,7 @@
 								continue;
 							}
 
-							let variant = variants[v],
+							var variant = variants[v],
 								fontWeight = +variant.replace(/i$/,'');
 
 							v > 0 && $variants.append(' '); // Separate by space
@@ -5674,7 +5674,7 @@
 						family: family,
 						weight: weight,
 						italic: italic
-					}
+					};
 				},
 
 				/**
@@ -5977,8 +5977,8 @@
                     var fontType = "";
                     var fontFamily = "";
                     var font = undefined;
-					for (var f = 0; f < fonts.length; f++) {
-						tmp = fonts[f].split(':'), fontType = tmp[0], fontFamily = tmp[1], font = this.allFonts[fontType][fontFamily];
+					for (var ff = 0; ff < fonts.length; ff++) {
+						tmp = fonts[ff].split(':'), fontType = tmp[0], fontFamily = tmp[1], font = this.allFonts[fontType][fontFamily];
 						if (!font) { continue; }
 
 						$orgLi = $("[data-font-family='" + fontFamily + "']", this.$results);
@@ -6029,7 +6029,7 @@
 							self.$select
 							.removeAttr('style')
 							.find('.fp-fontspec')
-							.html(self.dictionary['selectFont']);;
+							.html(self.dictionary['selectFont']);
 
 							self.$original.val('').change(); // Update original <input> element
 						}));
@@ -8504,5 +8504,4 @@
 
 });
 
-
-start()
+start();

--- a/Jellyfin.Plugin.SkinManager/Jellyfin.Plugin.SkinManager.csproj
+++ b/Jellyfin.Plugin.SkinManager/Jellyfin.Plugin.SkinManager.csproj
@@ -1,4 +1,4 @@
-﻿﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>

--- a/Jellyfin.Plugin.SkinManager/Jellyfin.Plugin.SkinManager.csproj
+++ b/Jellyfin.Plugin.SkinManager/Jellyfin.Plugin.SkinManager.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
@@ -27,15 +27,8 @@
 
   <ItemGroup>
     <Reference Include="MediaBrowser.Api">
-      <!--<HintPath>..\..\..\..\..\..\Program Files\Jellyfin\Server\MediaBrowser.Api.dll</HintPath>MediaBrowser.Common.dll-->
-      <HintPath>C:\Program Files\Jellyfin\Server\MediaBrowser.Api.dll</HintPath>
+      <HintPath>..\..\..\..\..\..\Program Files\Jellyfin\Server\MediaBrowser.Api.dll</HintPath>
     </Reference>
-    <!--<Reference Include="MediaBrowser.Common">
-      <HintPath>C:\Program Files\Jellyfin\Server\MediaBrowser.Common.dll</HintPath>
-    </Reference>
-    <Reference Include="MediaBrowser.Model">
-      <HintPath>C:\Program Files\Jellyfin\Server\MediaBrowser.Model.dll</HintPath>
-    </Reference>-->
   </ItemGroup>
 
 </Project>

--- a/Jellyfin.Plugin.SkinManager/Jellyfin.Plugin.SkinManager.csproj
+++ b/Jellyfin.Plugin.SkinManager/Jellyfin.Plugin.SkinManager.csproj
@@ -27,8 +27,15 @@
 
   <ItemGroup>
     <Reference Include="MediaBrowser.Api">
-      <HintPath>..\..\..\..\..\..\Program Files\Jellyfin\Server\MediaBrowser.Api.dll</HintPath>
+      <!--<HintPath>..\..\..\..\..\..\Program Files\Jellyfin\Server\MediaBrowser.Api.dll</HintPath>MediaBrowser.Common.dll-->
+      <HintPath>C:\Program Files\Jellyfin\Server\MediaBrowser.Api.dll</HintPath>
     </Reference>
+    <!--<Reference Include="MediaBrowser.Common">
+      <HintPath>C:\Program Files\Jellyfin\Server\MediaBrowser.Common.dll</HintPath>
+    </Reference>
+    <Reference Include="MediaBrowser.Model">
+      <HintPath>C:\Program Files\Jellyfin\Server\MediaBrowser.Model.dll</HintPath>
+    </Reference>-->
   </ItemGroup>
 
 </Project>

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
Fixes issue when saving rgba colors, values were converted 6 digit hex, losing transparent information.
Now saves rgba as rgba, and hex as hex by comparing color value to regex to determine correct color mode.

Also adds nuget.config, and cleans up minor errors in fontpicker.js 